### PR TITLE
Change RNTooltips extended class to PureComponent

### DIFF
--- a/RNTooltips.js
+++ b/RNTooltips.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import {
   findNodeHandle,
   ViewPropTypes,
@@ -9,7 +9,7 @@ import PropTypes from "prop-types";
 
 let { RNTooltips } = NativeModules;
 
-class Tooltips extends Component {
+class Tooltips extends PureComponent {
   static POSITION: {
     LEFT: 1,
     RIGHT: 2,


### PR DESCRIPTION
# Change logs

- Change the class extended by RNTooltips from Component to PureComponent in order to bring shallow-comparison and avoid to create a new popup each time the parent view re-render.

