### PR TITLE
Fix Android: View.getParent() on a null object reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,8 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
-      
+Podfile.lock
+Pods/
 
 # Android/IntelliJ
 #

--- a/android/src/main/java/com/reactlibrary/RNTooltipsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNTooltipsModule.java
@@ -38,6 +38,12 @@ public class RNTooltipsModule extends ReactContextBaseJavaModule {
     final Activity activity = this.getCurrentActivity();
     final ViewGroup target = activity.findViewById(view);
 
+    if (target == null) {
+        // The reference to the component haven't been rendered on the js side yet.
+        // View id doesn't exist on the native side yet.
+        return;
+    }
+
     String text = props.getString("text");
     int position = props.getInt("position");
     int align = props.getInt("align");


### PR DESCRIPTION
# Change logs

- Add a condition to verify that `target` is not equal to `null` in the `Show` method.

# Pull Request

This fix the issue #12 