### PR TITLE
Add parent view reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,55 +70,51 @@ allprojects {
     - After `react-native link react-native-tooltips`, please verify `node_modules/react-native-tooltips/ios/` contains Pods folder. If does not exist please execute `pod install` command on `node_modules/react-native-tooltips/ios/`, if any error => try `pod repo` update then `pod install`
 
 
-
 ## 💻 Usage
 
 ```javascript
 import RNTooltips from 'react-native-tooltips';
-
 ```
-
 
 - React Way
 
 ```javascript
-<RNTooltips text={"Long Press Description"} visible={this.state.visible} reference={this.state.reference} parent={this.state.parent} />
+<RNTooltips text={"Long Press Description"} visible={this.state.visible} target={this.state.target} parent={this.state.parent} />
 ```
 
 - API Way
 
 ```javascript
 RNTooltips.Show(
-    this.state.reference,
+    this.state.target,
     this.state.parent,
     {
         text: 'Long Press Description'
     }
 )
-
 ```
 
 ## 💡 Props
 
 - **Props: Generic**
 
-| Prop              | Type       | Default | Note                                                                                                       |
-| ----------------- | ---------- | ------- | ---------------------------------------------------------------------------------------------------------- |
-| `text`       | `string`     |         | Text which needs to be displayed
-| `autoHide`     | `bool` |         | Should tip view get auto dismiss                                                      |
-| `duration` | `number` |         | Duration after which tooltip view should be dismissed                                                  |  |
-| `clickToHide`    | `bool`     |         | On click should tooltip view be dismissed                                        |  |
-| `corner`      | `number`     |         | Radius of corner
-| `tintColor`      | `string`     |         | Color of tooltip view background
-| `textColor`      | `string`     |         | Color of text
-| `textSize`      | `number`     |         | Size of text displayed
-| `gravity`      | `number`     |         | Gravity of text
-| `visible`      | `bool`     |         | Should tooltip be displayed
-| `shadow`      | `bool`     |         | Shadow on tooltip view
-| `arrow`      | `bool`     |    true     | Display Arrow
-| `reference` | `object`     |         | Reference of react component of which you need the tooltip
-| `parent`      | `object`     |         | Reference of the parent component of which you need the tooltip to fit in
-| `onHide`      | `func`     |         | Callback function invoked on tooltip hide
+| Prop | Type | Default | Note |
+| --- | --- | --- | --- |
+| `text` | `string` | | Text which needs to be displayed
+| `autoHide` | `bool` | | Should tip view get auto dismiss |
+| `duration` | `number` | | Duration after which tooltip view should be dismissed |  |
+| `clickToHide` | `bool` | | On click should tooltip view be dismissed |  |
+| `corner` | `number` | | Radius of corner
+| `tintColor` | `string` | | Color of tooltip view background
+| `textColor` | `string` | | Color of text
+| `textSize` | `number` | | Size of text displayed
+| `gravity` | `number` | | Gravity of text
+| `visible` | `bool` | | Should tooltip be displayed
+| `shadow` | `bool` | | Shadow on tooltip view
+| `arrow` | `bool` | true | Display Arrow
+| `target` | `object` | | Reference of react component of which you need the tooltip
+| `parent` | `object` | | Reference of the parent component of which you need the tooltip to fit in
+| `onHide` | `func` | | Callback function invoked on tooltip hide
 
 
 - **Props - iOS**

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ import RNTooltips from 'react-native-tooltips';
 - React Way
 
 ```javascript
-<RNTooltips text={"Long Press Description"} visible={this.state.visible} reference={this.state.reference} />
+<RNTooltips text={"Long Press Description"} visible={this.state.visible} reference={this.state.reference} parent={this.state.parent} />
 ```
 
 - API Way
@@ -90,6 +90,7 @@ import RNTooltips from 'react-native-tooltips';
 ```javascript
 RNTooltips.Show(
     this.state.reference,
+    this.state.parent,
     {
         text: 'Long Press Description'
     }
@@ -115,7 +116,8 @@ RNTooltips.Show(
 | `visible`      | `bool`     |         | Should tooltip be displayed
 | `shadow`      | `bool`     |         | Shadow on tooltip view
 | `arrow`      | `bool`     |    true     | Display Arrow
-| `reference`      | `object`     |         | Reference of react component of which you need tooltip
+| `reference` | `object`     |         | Reference of react component of which you need the tooltip
+| `parent`      | `object`     |         | Reference of the parent component of which you need the tooltip to fit in
 | `onHide`      | `func`     |         | Callback function invoked on tooltip hide
 
 

--- a/RNTooltips.js
+++ b/RNTooltips.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
 import {
   findNodeHandle,
   ViewPropTypes,
@@ -47,6 +47,7 @@ class Tooltips extends PureComponent {
     arrow: PropTypes.bool,
     visible: PropTypes.bool,
     reference: PropTypes.object,
+    parent: PropTypes.object,
     onHide: PropTypes.func
   };
 
@@ -66,9 +67,12 @@ class Tooltips extends PureComponent {
     shadow: true
   };
 
-  static Show(ref, props) {
-    if (typeof ref !== 'number') {
+  static Show(ref, parent, props) {
+    if (typeof ref !== "number") {
       ref = findNodeHandle(ref);
+    }
+    if (typeof parent !== "number") {
+      parent = findNodeHandle(parent);
     }
 
     if (props.text === undefined) {
@@ -108,16 +112,12 @@ class Tooltips extends PureComponent {
       props.shadow = Tooltips.defaultProps.shadow;
     }
     if (props.arrow === undefined) {
-      props.arrow = Tooltips.defaultProps.arrow
+      props.arrow = Tooltips.defaultProps.arrow;
     }
 
-    RNTooltips.Show(
-      ref,
-      props,
-      () => {
-        props.onHide && props.onHide()
-      }
-    );
+    RNTooltips.Show(ref, parent, props, () => {
+      props.onHide && props.onHide();
+    });
   }
 
   static Dismiss(ref) {
@@ -129,25 +129,39 @@ class Tooltips extends PureComponent {
   }
 
   componentDidUpdate() {
-    if (this.props.visible === true && this.props.reference) {
-      Tooltips.Show(findNodeHandle(this.props.reference), {
-        text: this.props.text,
-        position: this.props.position,
-        align: this.props.align,
-        autoHide: this.props.autoHide,
-        duration: this.props.duration,
-        clickToHide: this.props.clickToHide,
-        corner: this.props.corner,
-        tintColor: this.props.tintColor,
-        textColor: this.props.textColor,
-        textSize: this.props.textSize,
-        arrow: this.props.arrow,
-        gravity: this.props.gravity,
-        shadow: this.props.shadow,
-        onHide: this.props.onHide
-      });
+    if (
+      this.props.visible === true &&
+      this.props.reference &&
+      this.props.parent
+    ) {
+      Tooltips.Show(
+        findNodeHandle(this.props.reference),
+        findNodeHandle(this.props.parent),
+        {
+          text: this.props.text,
+          position: this.props.position,
+          align: this.props.align,
+          autoHide: this.props.autoHide,
+          duration: this.props.duration,
+          clickToHide: this.props.clickToHide,
+          corner: this.props.corner,
+          tintColor: this.props.tintColor,
+          textColor: this.props.textColor,
+          textSize: this.props.textSize,
+          arrow: this.props.arrow,
+          gravity: this.props.gravity,
+          shadow: this.props.shadow,
+          onHide: this.props.onHide
+        }
+      );
     } else if (this.props.visible === false && this.props.reference) {
-      Tooltips.Dismiss(findNodeHandle(this.props.reference))
+      Tooltips.Dismiss(findNodeHandle(this.props.reference));
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.reference) {
+      Tooltips.Dismiss(findNodeHandle(this.props.reference));
     }
   }
 

--- a/RNTooltips.js
+++ b/RNTooltips.js
@@ -46,7 +46,7 @@ class Tooltips extends PureComponent {
     shadow: PropTypes.bool,
     arrow: PropTypes.bool,
     visible: PropTypes.bool,
-    reference: PropTypes.object,
+    target: PropTypes.object,
     parent: PropTypes.object,
     onHide: PropTypes.func
   };
@@ -67,9 +67,9 @@ class Tooltips extends PureComponent {
     shadow: true
   };
 
-  static Show(ref, parent, props) {
-    if (typeof ref !== "number") {
-      ref = findNodeHandle(ref);
+  static Show(target, parent, props) {
+    if (typeof target !== "number") {
+      target = findNodeHandle(target);
     }
     if (typeof parent !== "number") {
       parent = findNodeHandle(parent);
@@ -115,27 +115,23 @@ class Tooltips extends PureComponent {
       props.arrow = Tooltips.defaultProps.arrow;
     }
 
-    RNTooltips.Show(ref, parent, props, () => {
+    RNTooltips.Show(target, parent, props, () => {
       props.onHide && props.onHide();
     });
   }
 
-  static Dismiss(ref) {
-    if (typeof ref !== "number") {
-      ref = findNodeHandle(ref);
+  static Dismiss(target) {
+    if (typeof target !== "number") {
+      target = findNodeHandle(target);
     }
 
-    RNTooltips.Dismiss(ref);
+    RNTooltips.Dismiss(target);
   }
 
   componentDidUpdate() {
-    if (
-      this.props.visible === true &&
-      this.props.reference &&
-      this.props.parent
-    ) {
+    if (this.props.visible === true && this.props.target && this.props.parent) {
       Tooltips.Show(
-        findNodeHandle(this.props.reference),
+        findNodeHandle(this.props.target),
         findNodeHandle(this.props.parent),
         {
           text: this.props.text,
@@ -154,14 +150,15 @@ class Tooltips extends PureComponent {
           onHide: this.props.onHide
         }
       );
-    } else if (this.props.visible === false && this.props.reference) {
-      Tooltips.Dismiss(findNodeHandle(this.props.reference));
+    } else if (this.props.visible === false && this.props.target) {
+      Tooltips.Dismiss(findNodeHandle(this.props.target));
     }
   }
 
   componentWillUnmount() {
-    if (this.props.reference) {
-      Tooltips.Dismiss(findNodeHandle(this.props.reference));
+    if (Platform.OS === "android" && this.props.target) {
+      // this isn't required for iOS, but android tooltips have issues to disappear
+      Tooltips.Dismiss(findNodeHandle(this.props.target));
     }
   }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.github.florent37:viewtooltip:1.1.5'
+    compile 'com.github.florent37:viewtooltip:1.1.6'
 }
   

--- a/ios/RNTooltips.m
+++ b/ios/RNTooltips.m
@@ -1,7 +1,4 @@
-
 #import "RNTooltips.h"
-
-
 
 @interface TooltipDelegate : NSObject <SexyTooltipDelegate>
 
@@ -31,29 +28,35 @@ SexyTooltip *toolTip;
 RCT_EXPORT_MODULE()
 
 
-RCT_EXPORT_METHOD(Show:(nonnull NSNumber *)view props:(NSDictionary *)props onHide:(RCTResponseSenderBlock)onHide)
+RCT_EXPORT_METHOD(Show:(nonnull NSNumber *)targetViewTag inParentView:(nonnull NSNumber *)parentViewTag props:(NSDictionary *)props onHide:(RCTResponseSenderBlock)onHide)
 {
-    UIView *target = [self.bridge.uiManager viewForReactTag: view];
+  UIView *target = [self.bridge.uiManager viewForReactTag: targetViewTag];
+  UIView *parentView = [self.bridge.uiManager viewForReactTag:parentViewTag];
+  if (!parentView) {
+    // parent is null, then return
+    return;
+  }
     
-    NSString *text = [props objectForKey: @"text"];
-    NSNumber *position = [props objectForKey: @"position"];
-    NSNumber *align = [props objectForKey: @"align"];
-    NSNumber *autoHide = [props objectForKey: @"autoHide"];
-    NSNumber *duration = [props objectForKey: @"duration"];
-    NSNumber *clickToHide = [props objectForKey: @"clickToHide"];
-    NSNumber *corner = [props objectForKey: @"corner"];
-    NSString *tintColor = [props objectForKey: @"tintColor"];
-    NSString *textColor = [props objectForKey: @"textColor"];
-    NSNumber *textSize = [props objectForKey: @"textSize"];
-    NSNumber *gravity = [props objectForKey: @"gravity"];
-    NSNumber *shadow = [props objectForKey: @"shadow"];
-    NSNumber *arrow = [props objectForKey: @"arrow"];
+  NSString *text = [props objectForKey: @"text"];
+//  NSNumber *position = [props objectForKey: @"position"]; // not used yet
+//  NSNumber *align = [props objectForKey: @"align"]; // not used yet
+  NSNumber *autoHide = [props objectForKey: @"autoHide"];
+  NSNumber *duration = [props objectForKey: @"duration"];
+  NSNumber *clickToHide = [props objectForKey: @"clickToHide"];
+  NSNumber *corner = [props objectForKey: @"corner"];
+  NSString *tintColor = [props objectForKey: @"tintColor"];
+  NSString *textColor = [props objectForKey: @"textColor"];
+  NSNumber *textSize = [props objectForKey: @"textSize"];
+//  NSNumber *gravity = [props objectForKey: @"gravity"]; not used yet
+  NSNumber *shadow = [props objectForKey: @"shadow"];
+  NSNumber *arrow = [props objectForKey: @"arrow"];
 
     NSMutableAttributedString *attributes = [[NSMutableAttributedString alloc] initWithString: text];
     [attributes addAttribute:NSForegroundColorAttributeName value:[RNTooltips colorFromHexCode: textColor] range:NSMakeRange(0, text.length)];
     [attributes addAttribute:NSFontAttributeName value: [UIFont systemFontOfSize: [textSize floatValue]] range:NSMakeRange(0,text.length)];
 
-    toolTip = [[SexyTooltip alloc] initWithAttributedString: attributes];
+    toolTip = [[SexyTooltip alloc] initWithAttributedString: attributes sizedToView:parentView];
+    toolTip.layer.zPosition = 9999; // make sure the tooltips is always in front of other views.
 
     TooltipDelegate *delegate = [[TooltipDelegate alloc] init];
     delegate.onHide = onHide;
@@ -62,7 +65,7 @@ RCT_EXPORT_METHOD(Show:(nonnull NSNumber *)view props:(NSDictionary *)props onHi
     toolTip.color = [RNTooltips colorFromHexCode: tintColor];
     toolTip.cornerRadius = [corner floatValue];
     toolTip.dismissesOnTap = [clickToHide boolValue];
-    toolTip.padding = UIEdgeInsetsMake(6, 8, 6, 8);
+    toolTip.padding = UIEdgeInsetsMake(6.0, 8.0, 6.0, 8.0);
     
     if (![arrow boolValue]) {
         toolTip.arrowHeight = 0;
@@ -78,11 +81,13 @@ RCT_EXPORT_METHOD(Show:(nonnull NSNumber *)view props:(NSDictionary *)props onHi
 }
 
 RCT_EXPORT_METHOD(Dismiss:(nonnull NSNumber *)view) {
-
-    if (toolTip == nil) return;
-
-    [toolTip dismiss];
-    toolTip = nil;
+  
+  if (toolTip == nil) {
+    return;
+  }
+  
+  [toolTip dismiss];
+  toolTip = nil;
 }
 
 
@@ -108,7 +113,6 @@ RCT_EXPORT_METHOD(Dismiss:(nonnull NSNumber *)view) {
     
     return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
 }
-
 
 @end
   


### PR DESCRIPTION
# Change logs

- Now users need to give a reference to the `parent` view where they want the tooltip to fit in. This avoid the tooltip to go off-screen.
- Dismiss the tooltips when `componentWillUnmount()`.
- Upgrade the version number of the dependency `com.github.florent37:viewtooltip` to `1.1.6` on Android to take benefit of method `on` that can retrieve its parent view by itself.

## Notes

On Android `findNodeHandle` might not retrieve the right `viewId` which end up by having the `findViewById` to return `null`. This previously caused a crash which has been fixed in #13. 

In order to avoid this bug, developers must set `collapsable={false}` in the props of their component.

## Suggestion

I would like to change the name of the props `reference` to `target` to make it more explicit for developers when they set the props to `RNTooltips`. 