### PR TITLE
Fix for lint-gradle-api.jar not found in jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
         maven { url "https://maven.google.com" }
     }


### PR DESCRIPTION
I added google() and I was able to run 'react-native run-android' without getting the lint-gradle-api.jar error.