### PR TITLE
Fix build failure on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,8 @@
 
 buildscript {
     repositories {
+        google()
+        mavenCentral()
         jcenter()
         maven { url "https://maven.google.com" }
     }


### PR DESCRIPTION
(Getting: “Couldn't locate lint-gradle-api-26.1.2.jar”)