### PR TITLE
Bugfix: avoid double invocation, add exception handling

### DIFF
--- a/android/src/main/java/px/tooltips/RNTooltipsModule.java
+++ b/android/src/main/java/px/tooltips/RNTooltipsModule.java
@@ -3,6 +3,7 @@ package px.tooltips;
 
 import android.app.Activity;
 import android.graphics.Color;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
@@ -103,9 +104,17 @@ public class RNTooltipsModule extends ReactContextBaseJavaModule {
               tooltip = tooltip.withShadow(shadow);
 
               tooltip.onHide(new ViewTooltip.ListenerHide() {
+                boolean invoked = false;
                 @Override
                 public void onHide(View view) {
-                  onHide.invoke();
+                  // avoid double execution of the callback, which would cause RuntimeException
+                  if (invoked) return;
+                  else invoked = true;
+                  try {
+                    onHide.invoke();
+                  } catch (RuntimeException e) {
+                    Log.w("RNTooltips","Double invocation of callback", e);
+                  }
                 }
               });
 


### PR DESCRIPTION
The double invocation may be caused by the wrapped android library.
I added a flag that will indicate if the callback had already been invoked as safeguard, furthermore wrapped it in a try catch clause to avoid the app crashing