### PR TITLE
Fix  "Could not find com.github.florent37:viewtooltip:1.1.6"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,5 +36,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.florent37:viewtooltip:1.1.6'
+    cimplementation 'com.github.florent37:ViewTooltip:f79a8955ef'
 }


### PR DESCRIPTION
Fix "Could not find com.github.florent37:viewtooltip:1.1.6." error on grade build.